### PR TITLE
feat: 环境安装缺少setuptools包，已经在requirements中补上

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ funasr>=1.1.2
 numpy<=1.26.4
 gradio
 fastapi
+setuptools


### PR DESCRIPTION
我在本地一开始无python环境按步骤安装部署，运行python时候显示少了这个包。